### PR TITLE
added type:module attribute to src tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>Developer Shell</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script defer src="js/index.js"></script>
+    <script defer type="module" src="js/index.js"></script>
     <link rel="stylesheet" href="css/index.css">
   </head>
   <body>


### PR DESCRIPTION
Parcel build will fail trying to include imports in script without type attribute added to script tag. Updated, parcel documentation referenced: https://parceljs.org/languages/javascript/#classic-scripts